### PR TITLE
Add “module” field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "16.8.30",
   "description": "An ES6 module exposing the latest version of react and react-dom",
   "main": "index.js",
+  "module": "index.js",
   "keywords": ["react", "es", "module", "import", "export"],
   "author": "@lukejacksonn",
   "license": "MIT"


### PR DESCRIPTION
Allows tools like @pika/web & indexers like www.pikapkg.com to detect that this package contains ES Module code.

See: https://github.com/rollup/rollup/wiki/pkg.module