### PR TITLE
feat: add entry point for react-dom-server-browser

### DIFF
--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -10,6 +10,7 @@ const exportsMap = (isProduction = false) => ({
   react: `react/cjs/react.${isProduction ? 'production.min' : 'development'}.js`,
   'react-is': `react-is/cjs/react-is.${isProduction ? 'production.min' : 'development'}.js`,
   'react-dom': `react-dom/cjs/react-dom.${isProduction ? 'production.min' : 'development'}.js`,
+  'react-dom-server-browser': `react-dom/cjs/react-dom-server.browser.${isProduction ? 'production.min' : 'development'}.js`,
   'prop-types': 'prop-types/index.js',
 });
 
@@ -19,6 +20,7 @@ const config = (isProduction = false) => ({
     react: './src/react.js',
     'react-is': './src/react-is.js',
     'react-dom': './src/react-dom.js',
+    'react-dom-server-browser': './src/react-dom-server-browser.js',
     'prop-types': './src/prop-types.js'
   },
   plugins: [
@@ -44,6 +46,7 @@ const config = (isProduction = false) => ({
         react: Object.keys(require('react')),
         'react-is': Object.keys(require('react-is')),
         'react-dom': Object.keys(require('react-dom')),
+        'react-dom-server-browser': Object.keys(require('react-dom/server.browser')),
         'prop-types': Object.keys(require('prop-types')),
       },
     }),

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 import React from './react';
 import ReactDOM from './react-dom';
+import ReactDOMServerBrowser from './react-dom';
 import PropTypes from './prop-types';
 
-export { React, ReactDOM, PropTypes };
+export { React, ReactDOM, ReactDOMServerBrowser, PropTypes };
 export * from './react';
 export default React;

--- a/src/react-dom-server-browser.js
+++ b/src/react-dom-server-browser.js
@@ -1,0 +1,1 @@
+export { default } from 'react-dom/server.browser';


### PR DESCRIPTION
This adds an export for `react-dom/server.browser` for use in [Deno](https://deno.land/).

(exposed as `ReactDOMServerBrowser`)

Here's a working usage example. https://github.com/iAmNathanJ/deno-react

Related to #2 