### PR TITLE
Fix ReactDOMServerBrowser export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from './react';
 import ReactDOM from './react-dom';
-import ReactDOMServerBrowser from './react-dom';
+import ReactDOMServerBrowser from './react-dom-server-browser';
 import PropTypes from './prop-types';
 
 export { React, ReactDOM, ReactDOMServerBrowser, PropTypes };


### PR DESCRIPTION
The ReactDOMServerBrowser export in src/index.js was exporting `./react-dom`, not `./react-dom-server-browser`