### PR TITLE
include types in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@
 !*.js
 !README.md
 !package.json
+!/*.d.ts


### PR DESCRIPTION
The TypeScript types are missing in the npm package because they're `.npmignore`d. The package ends up pointing to `"types": "index.d.ts"` but `index.d.ts` isn't there. This change includes the type files.